### PR TITLE
README.md: Add instructions to create own OAuth Client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ And _voilà_! Auth an account via the commandline to start syncing:
 
     bin/inbox-auth ben.bitdiddle1861@gmail.com
 
+Because authentication uses a sample client key/secret by default, it is recommended that you use the [Google Developer Console](https://console.developers.google.com) and the Windows Dev Center to create a new OAuth 2.0 Client ID.
+
+For Google, add the Gmail, Calendar, and Contacts APIs, and then generate a *Client ID for Native Application*. Then, replace the sample credentials in `/etc/inboxapp/secrets.yml` and run `bin/inbox-auth your@email.com`.
+
 
 
 ## Provider compatibility


### PR DESCRIPTION
Currently, the user is authenticating their email account to a shared OAuth Client ID, to which everyone has the client ID and the secret to. This seems insecure. This change updates the README.md to add instructions on how to create one's own OAuth Client ID and add it to `secrets.yml`.

If I'm not off base, in the future, Inbox should think about removing the sample credentials and forcing people to create an OAuth pair by themselves. Less of a nice demo, but potentially more secure.