### PR TITLE
Store full_body before attempting to parse the message.

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -199,6 +199,13 @@ class Message(MailSyncBase, HasRevisions, HasPublicID):
             msg.namespace_id = account.namespace.id
             parsed = mime.from_string(body_string)
 
+            from inbox.models.block import Block, Part
+            body_block = Block()
+            body_block.namespace_id = account.namespace.id
+            body_block.data = body_string
+            body_block.content_type = "text/plain"
+            msg.full_body = body_block
+
             mime_version = parsed.headers.get('Mime-Version')
             # sometimes MIME-Version is '1.0 (1.0)', hence the .startswith()
             if mime_version is not None and not mime_version.startswith('1.0'):
@@ -230,13 +237,6 @@ class Message(MailSyncBase, HasRevisions, HasPublicID):
             msg.references = parse_references(
                 parsed.headers.get('References', ''),
                 parsed.headers.get('In-Reply-To', ''))
-
-            from inbox.models.block import Block, Part
-            body_block = Block()
-            body_block.namespace_id = account.namespace.id
-            body_block.data = body_string
-            body_block.content_type = "text/plain"
-            msg.full_body = body_block
 
             msg.size = len(body_string)  # includes headers text
 

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -196,15 +196,15 @@ class Message(MailSyncBase, HasRevisions, HasPublicID):
         msg = Message()
 
         try:
-            msg.namespace_id = account.namespace.id
-            parsed = mime.from_string(body_string)
-
             from inbox.models.block import Block, Part
             body_block = Block()
             body_block.namespace_id = account.namespace.id
             body_block.data = body_string
             body_block.content_type = "text/plain"
             msg.full_body = body_block
+
+            msg.namespace_id = account.namespace.id
+            parsed = mime.from_string(body_string)
 
             mime_version = parsed.headers.get('Mime-Version')
             # sometimes MIME-Version is '1.0 (1.0)', hence the .startswith()

--- a/tests/data/raw_message_with_bad_date
+++ b/tests/data/raw_message_with_bad_date
@@ -1,0 +1,6 @@
+From: from@example.com
+To: to@example.com
+Date: unparseable
+Subject: hello
+
+Hello world

--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -39,6 +39,15 @@ def raw_message_with_bad_content_disposition():
         return f.read()
 
 
+@pytest.fixture
+def raw_message_with_bad_date():
+    # Message with a MIME part that has an invalid content-disposition.
+    raw_msg_path = full_path(
+        '../data/raw_message_with_bad_date')
+    with open(raw_msg_path) as f:
+        return f.read()
+
+
 def test_message_from_synced(db, default_account, default_namespace,
                              raw_message):
     received_date = datetime.datetime(2014, 9, 22, 17, 25, 46)
@@ -137,3 +146,13 @@ def test_handle_bad_content_disposition(
     assert len(m.parts) == 3
     assert m.received_date == received_date
     assert all(part.block.namespace_id == m.namespace_id for part in m.parts)
+
+
+def test_store_full_body_on_parse_error(
+        default_account, default_namespace,
+        raw_message_with_bad_date):
+    received_date = None
+    m = Message.create_from_synced(default_account, 139219, '[Gmail]/All Mail',
+                                   received_date,
+                                   raw_message_with_bad_date)
+    assert m.full_body


### PR DESCRIPTION
Assigning the `full_body` early ensures we can still access the full RFC2822 body even if there's an error while parsing the actual message.